### PR TITLE
Add profile endpoint service

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+## Profile Endpoints
+
+The application retrieves the current user's profile based on their role:
+
+- **Influencers**: `GET /profiles/influencer/me`
+- **Brands**: `GET /profiles/brand/me`
+
+`ProfileMeService` handles these requests using a token stored in `localStorage`.

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -14,16 +14,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'InfluMatch-WebApplication' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('InfluMatch-WebApplication');
-  });
-
-  it('should render title', () => {
+  it('should render router outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, InfluMatch-WebApplication');
+    expect(compiled.querySelector('router-outlet')).not.toBeNull();
   });
 });

--- a/src/app/features/dashboard/pages/profile/profile.component.ts
+++ b/src/app/features/dashboard/pages/profile/profile.component.ts
@@ -1,14 +1,18 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatChipsModule } from '@angular/material/chips';
-import { environment } from '../../../../../environments/environment';
 import { AuthService } from '../../../../core/services/auth.service';
+import { ProfileMeService } from '../../../../infrastructure/services/profile-me.service';
+import {
+  InfluencerProfileResponse,
+  BrandProfileResponse,
+} from '../../../../infrastructure/dtos/profile-me.dto';
 
 @Component({
   selector: 'app-profile',
@@ -30,30 +34,32 @@ export class ProfileComponent implements OnInit {
   loading = true;
   error = false;
 
-  constructor(private authService: AuthService, private http: HttpClient) {}
+  constructor(
+    private authService: AuthService,
+    private profileMeService: ProfileMeService
+  ) {}
 
   ngOnInit(): void {
     // Obtener el usuario actual del AuthService
     const currentUser = this.authService.currentUser;
 
     if (currentUser) {
-      // Consultar la API para obtener los datos completos del perfil
-      this.http
-        .get(`${environment.apiBase}/users-register/${currentUser.userId}`)
-        .subscribe({
-          next: (userData: any) => {
-            this.user = userData;
-            this.loading = false;
-          },
-          error: (err) => {
-            console.error('Error al cargar el perfil:', err);
-            this.error = true;
-            this.loading = false;
+      const request$: Observable<InfluencerProfileResponse | BrandProfileResponse> =
+        currentUser.profileType === 'INFLUENCER'
+          ? this.profileMeService.getInfluencerProfile()
+          : this.profileMeService.getBrandProfile();
 
-            // Si falla la consulta, usar los datos que ya tenemos del login
-            this.user = currentUser;
-          },
-        });
+      request$.subscribe({
+        next: (userData: InfluencerProfileResponse | BrandProfileResponse) => {
+          this.user = userData;
+          this.loading = false;
+        },
+        error: (err) => {
+          console.error('Error al cargar el perfil:', err);
+          this.error = true;
+          this.loading = false;
+        }
+      });
     } else {
       this.error = true;
       this.loading = false;
@@ -74,6 +80,10 @@ export class ProfileComponent implements OnInit {
   getTotalFollowers(): number {
     if (!this.user?.followers) return 0;
 
+    if (typeof this.user.followers === 'number') {
+      return this.user.followers;
+    }
+
     let total = 0;
     if (this.user.followers.instagram) total += this.user.followers.instagram;
     if (this.user.followers.tiktok) total += this.user.followers.tiktok;
@@ -84,9 +94,6 @@ export class ProfileComponent implements OnInit {
 
   // Método para obtener las redes sociales como array
   getSocialLinks(): { platform: string; url: string; icon: string }[] {
-    if (!this.user?.social_links) return [];
-
-    const result = [];
     const icons: { [key: string]: string } = {
       instagram: 'instagram',
       facebook: 'facebook',
@@ -95,6 +102,17 @@ export class ProfileComponent implements OnInit {
       youtube: 'youtube',
     };
 
+    if (Array.isArray(this.user?.socialLinks)) {
+      return this.user.socialLinks.map((link: any) => ({
+        platform: link.platform,
+        url: link.url,
+        icon: icons[link.platform.toLowerCase()] || 'link',
+      }));
+    }
+
+    if (!this.user?.social_links) return [];
+
+    const result = [];
     for (const [platform, url] of Object.entries(this.user.social_links)) {
       if (url) {
         result.push({
@@ -110,11 +128,13 @@ export class ProfileComponent implements OnInit {
 
   // Método para verificar si es influencer
   isInfluencer(): boolean {
-    return this.user?.user_type === 'influencer';
+    const currentUser = this.authService.currentUser;
+    return currentUser?.profileType === 'INFLUENCER';
   }
 
   // Método para verificar si es marca
   isBrand(): boolean {
-    return this.user?.user_type === 'marca';
+    const currentUser = this.authService.currentUser;
+    return currentUser?.profileType === 'BRAND';
   }
 }

--- a/src/app/infrastructure/dtos/profile-me.dto.ts
+++ b/src/app/infrastructure/dtos/profile-me.dto.ts
@@ -1,0 +1,49 @@
+export interface SocialLink {
+  platform: string;
+  url: string;
+}
+
+export interface Link {
+  title: string;
+  url: string;
+}
+
+export interface Attachment {
+  title: string;
+  description: string;
+  mediaType: 'PHOTO' | 'VIDEO' | 'DOCUMENT';
+  data: string;
+}
+
+export interface InfluencerProfileResponse {
+  id: number;
+  name: string;
+  niches: string[];
+  bio: string;
+  country: string;
+  photo: string;
+  profilePhoto: string;
+  followers: number;
+  socialLinks: SocialLink[];
+  location: string;
+  links: Link[];
+  attachments: Attachment[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BrandProfileResponse {
+  id: number;
+  name: string;
+  sector: string;
+  country: string;
+  description: string;
+  logo: string;
+  profilePhoto: string;
+  websiteUrl: string;
+  location: string;
+  links: Link[];
+  attachments: Attachment[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/app/infrastructure/services/profile-me.service.ts
+++ b/src/app/infrastructure/services/profile-me.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { InfluencerProfileResponse, BrandProfileResponse } from '../dtos/profile-me.dto';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProfileMeService {
+  private readonly baseUrl = environment.apiBase;
+
+  constructor(private http: HttpClient) {}
+
+  private getHeaders(): HttpHeaders {
+    const token = localStorage.getItem('accessToken') || localStorage.getItem('access_token');
+    return new HttpHeaders().set('Authorization', `Bearer ${token}`);
+  }
+
+  getInfluencerProfile(): Observable<InfluencerProfileResponse> {
+    return this.http.get<InfluencerProfileResponse>(`${this.baseUrl}/profiles/influencer/me`, {
+      headers: this.getHeaders()
+    });
+  }
+
+  getBrandProfile(): Observable<BrandProfileResponse> {
+    return this.http.get<BrandProfileResponse>(`${this.baseUrl}/profiles/brand/me`, {
+      headers: this.getHeaders()
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add new DTO definitions for profile responses
- create `ProfileMeService` with token headers
- integrate service into profile page to fetch profile data based on user role
- document profile endpoints in README
- fix profile observable typing and update tests

## Testing
- `npx ng build`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684e6ade36b0832eb6651331bf283fb7